### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/EFilingExemptionSupremeCourt/data/questions/EFilingExemptionSupremeCourt.yml
+++ b/docassemble/EFilingExemptionSupremeCourt/data/questions/EFilingExemptionSupremeCourt.yml
@@ -646,14 +646,14 @@ attachment:
       - "unable_to": ${ other_reasons.all_true('unable_to') }
       - "user_address_one": ${ users[0].address.line_one(bare=True) }
       - "user_address_two": ${ users[0].address.line_two() }
-      - "user_name": ${ users[0].name.full(middle="full") }
+      - "user_name": ${ users[0].name_full() }
       - "user_email": ${ users[0].email if include_email_address == True else "" }
       - "user_phone": ${ phone_number_formatted(users[0].phone_number) if include_phone == True else "" }
       - "appellant_plaintiff": ${plaintiff_appellant}
       - "appellee_plaintiff": ${ plaintiff_appellee}
       - "appellant_defendant": ${ defendant_appellant}
       - "appellee_defendant": ${ defendant_appellee}
-      - "judge_name": ${judge.name.full(middle='full')}
+      - "judge_name": ${judge.name_full()}
       - "in_re": ${ in_re_label if in_re_check == True else ""}
       - "minor_involved": ${minor_involved}
       - "appellate_district": ${appellate_district}
@@ -684,7 +684,7 @@ review:
       **Your party: (Edit to change names)**
 
       % for my_var in users:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: anyone_opposing
     button: |
@@ -696,7 +696,7 @@ review:
       **The other party: (Edit to change names)**
 
       % for my_var in other_parties:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: anyone_opposing
   - Edit: trial_case_number
@@ -710,7 +710,7 @@ review:
       **Supreme Court case number:** ${supreme_case_number}
   - Edit: judge.name.first
     button: |
-      **Trial court judge:** ${ judge.name.full(middle='full')}
+      **Trial court judge:** ${ judge.name_full()}
   - Edit: in_re_check
     button: |
       **Does trial court case's caption say "In Re?"**  
@@ -768,7 +768,7 @@ review:
       **Which county was the trial court case in?:** ${ trial_court.address.county }
   - Edit: users[0].name.first
     button: |
-      **Your name:** ${ users[0].name.full(middle="full") }
+      **Your name:** ${ users[0].name_full() }
   - Edit: include_phone
     button: |
       **Do you want to include your phone number?**
@@ -798,7 +798,7 @@ table: users.table
 rows: users
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 delete buttons: True
 confirm: True
 ---
@@ -814,7 +814,7 @@ table: other_parties.table
 rows: other_parties
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 delete buttons: True
 confirm: True
 ---

--- a/docassemble/EFilingExemptionSupremeCourt/data/questions/e-filing_exemption_supreme_court.yml
+++ b/docassemble/EFilingExemptionSupremeCourt/data/questions/e-filing_exemption_supreme_court.yml
@@ -722,14 +722,14 @@ attachment:
       - "unable_to": ${ other_reasons.all_true('unable_to') }
       - "user_address_one": ${ users[0].address.line_one(bare=True) }
       - "user_address_two": ${ users[0].address.line_two() }
-      - "user_name": ${ users[0].name.full(middle="full") }
+      - "user_name": ${ users[0].name_full() }
       - "user_email": ${ users[0].email if include_email_address == True else "" }
       - "user_phone": ${ phone_number_formatted(users[0].phone_number) if include_phone == True else "" }
       - "appellant_plaintiff": ${plaintiff_appellant}
       - "appellee_plaintiff": ${ plaintiff_appellee}
       - "appellant_defendant": ${ defendant_appellant}
       - "appellee_defendant": ${ defendant_appellee}
-      - "judge_name": ${judge.name.full(middle='full')}
+      - "judge_name": ${judge.name_full()}
       - "in_re": ${ in_re_label if in_re_check == True else ""}
       - "minor_involved": ${minor_involved}
       - "appellate_district": ${appellate_district}
@@ -760,7 +760,7 @@ review:
       **Your party:**
 
       % for my_var in users:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: anyone_opposing
     button: |
@@ -772,7 +772,7 @@ review:
       **The other party: (Edit to change names)**
 
       % for my_var in other_parties:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: anyone_opposing
   - Edit: 
@@ -786,7 +786,7 @@ review:
       **Circuit court case number:** ${ trial_case_number }
   - Edit: judge.name.last
     button: |
-      **Circuit court judge:** ${ judge.name.full(middle='full')}
+      **Circuit court judge:** ${ judge.name_full()}
   - Edit: in_re_check
     button: |
       **Does circuit court case's caption say "In Re?"**  
@@ -877,7 +877,7 @@ table: users.table
 rows: users
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 delete buttons: True
@@ -896,7 +896,7 @@ table: other_parties.table
 rows: other_parties
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 delete buttons: True
@@ -956,7 +956,7 @@ review:
       **Your party:**
 
       % for my_var in users:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: anyone_opposing
     button: |
@@ -968,7 +968,7 @@ review:
       **The other party:**
 
       % for my_var in other_parties:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: anyone_opposing
   - Edit: trial_case_number
@@ -982,7 +982,7 @@ review:
       **Which county was the circuit court case in?** ${ trial_court.address.county }
   - Edit: judge.name.last
     button: |
-      **Circuit court judge:** ${ judge.name.full(middle='full')}
+      **Circuit court judge:** ${ judge.name_full()}
   - Edit: in_re_check
     button: |
       **Does circuit court case's caption say "In re:?"**  
@@ -1036,7 +1036,7 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
   - Edit: users[0].address.address
     button: |
       **Your address:**

--- a/docassemble/EFilingExemptionSupremeCourt/data/questions/efiling_exemption_supreme_court.yml
+++ b/docassemble/EFilingExemptionSupremeCourt/data/questions/efiling_exemption_supreme_court.yml
@@ -657,14 +657,14 @@ attachment:
       - "unable_to": ${ other_reasons.all_true('unable_to') }
       - "user_address_one": ${ users[0].address.line_one(bare=True) }
       - "user_address_two": ${ users[0].address.line_two() }
-      - "user_name": ${ users[0].name.full(middle="full") }
+      - "user_name": ${ users[0].name_full() }
       - "user_email": ${ users[0].email if include_email_address == True else "" }
       - "user_phone": ${ phone_number_formatted(users[0].phone_number) if include_phone == True else "" }
       - "appellant_plaintiff": ${plaintiff_appellant}
       - "appellee_plaintiff": ${ plaintiff_appellee}
       - "appellant_defendant": ${ defendant_appellant}
       - "appellee_defendant": ${ defendant_appellee}
-      - "judge_name": ${judge.name.full(middle='full')}
+      - "judge_name": ${judge.name_full()}
       - "in_re": ${ in_re_label if in_re_check == True else ""}
       - "minor_involved": ${minor_involved}
       - "appellate_district": ${appellate_district}
@@ -695,7 +695,7 @@ review:
       **Your party:**
 
       % for my_var in users:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: anyone_opposing
     button: |
@@ -707,7 +707,7 @@ review:
       **The other party: (Edit to change names)**
 
       % for my_var in other_parties:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: anyone_opposing
   - Edit: 
@@ -721,7 +721,7 @@ review:
       **Circuit court case number:** ${ trial_case_number }
   - Edit: judge.name.first
     button: |
-      **Circuit court judge:** ${ judge.name.full(middle='full')}
+      **Circuit court judge:** ${ judge.name_full()}
   - Edit: in_re_check
     button: |
       **Does circuit court case's caption say "In Re?"**  
@@ -806,7 +806,7 @@ table: users.table
 rows: users
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 delete buttons: True
@@ -824,7 +824,7 @@ table: other_parties.table
 rows: other_parties
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 delete buttons: True
@@ -884,7 +884,7 @@ review:
       **Your party:**
 
       % for my_var in users:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: anyone_opposing
     button: |
@@ -896,7 +896,7 @@ review:
       **The other party:**
 
       % for my_var in other_parties:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: anyone_opposing
 ---
@@ -918,7 +918,7 @@ review:
       **Which county was the circuit court case in?:** ${ trial_court.address.county }
   - Edit: judge.name.first
     button: |
-      **Circuit court judge:** ${ judge.name.full(middle='full')}
+      **Circuit court judge:** ${ judge.name_full()}
   - Edit: in_re_check
     button: |
       **Does circuit court case's caption say "In re:?"**  


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>